### PR TITLE
feat: run multiple brokers, create record reader

### DIFF
--- a/Dockerfile.nifi
+++ b/Dockerfile.nifi
@@ -1,8 +1,5 @@
 FROM apache/nifi:latest
 ADD --chown=nifi:nifi https://github.com/influxdata/nifi-influxdb-bundle/releases/download/v1.13.0/nifi-influx-database-nar-1.13.0.nar /opt/nifi/nifi-current/lib/
 COPY --chown=nifi:nifi MQTT-to-InfluxDB.xml /opt/nifi/nifi-current/conf/templates/
-# Not using these yet but would like to in the future so we don't have to keep configuring NiFi to use the template every time
-COPY --chown=nifi:nifi flow.xml.gz /opt/nifi/nifi-current/conf/flow-template.xml.gz
-COPY --chown=nifi:nifi nifi.properties /opt/nifi/nifi-current/conf/nifi-template.properties
 EXPOSE 8443
 ENTRYPOINT []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - '1883:1883'
       - '9001:9001'
     restart: unless-stopped
+    depends_on:
+      - nifi
   mosquitto2:
     container_name: mosquitto2
     image: eclipse-mosquitto:latest
@@ -31,6 +33,8 @@ services:
       - '1884:1883'
       - '9002:9001'
     restart: unless-stopped
+    depends_on:
+      - nifi
   mqtt1:
     container_name: mqtt1
     image: efrecon/mqtt-client

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,14 +11,42 @@ services:
     environment:
       - SINGLE_USER_CREDENTIALS_USERNAME=admin
       - SINGLE_USER_CREDENTIALS_PASSWORD=nifipassword
-  mosquitto:
-    container_name: mosquitto
+  mosquitto1:
+    container_name: mosquitto1
     image: eclipse-mosquitto:latest
     volumes:
       - ${PWD}/mosquitto.conf:/mosquitto/config/mosquitto.conf
-      - ${PWD}/mosquitto/data
-      - ${PWD}/mosquitto/log
+      - ${PWD}/mosquitto/data/1/
     ports:
       - '1883:1883'
       - '9001:9001'
     restart: unless-stopped
+  mosquitto2:
+    container_name: mosquitto2
+    image: eclipse-mosquitto:latest
+    volumes:
+      - ${PWD}/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - ${PWD}/mosquitto/data/2/
+    ports:
+      - '1884:1883'
+      - '9002:9001'
+    restart: unless-stopped
+  mqtt1:
+    container_name: mqtt1
+    image: efrecon/mqtt-client
+    command: pub -h host.docker.internal -p 1883 -t "/1" -i 1 -m 'mqtt,client=1 myfield="fieldvalue"'
+    volumes:
+      - ${PWD}/pubdata/:/pubdata/
+    depends_on:
+      - mosquitto1
+    restart: always
+  mqtt2:
+    container_name: mqtt2
+    image: efrecon/mqtt-client
+    command: pub -h host.docker.internal -p 1884 -t "/2" -i 2 -m 'mqtt,client=2 myfield="fieldvalue"'
+    volumes:
+      - ${PWD}/pubdata/:/pubdata/
+    depends_on:
+      - mosquitto2
+    restart: always
+

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,3 +1,4 @@
 persistence true
 persistence_location /mosquitto/data/
-log_dest file /mosquitto/log/mosquitto.log
+allow_anonymous true
+listener 1883

--- a/nifi.http
+++ b/nifi.http
@@ -99,7 +99,7 @@ Content-Type: application/json
 ###
 
 # Create ConsumeMQTT processor
-POST {{baseUrl}}/process-groups/{{processGroupFlowId}}/processors
+POST {{baseUrl}}/process-groups/{{processGroupId}}/processors
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -127,7 +127,7 @@ Content-Type: application/json
 ###
 
 # Create Put Influx Processor
-POST {{baseUrl}}/process-groups/{{processGroupFlowId}}/processors
+POST {{baseUrl}}/process-groups/{{processGroupId}}/processors
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -154,7 +154,7 @@ Content-Type: application/json
 ###
 
 # Link processors
-POST {{baseUrl}}/process-groups/{{processGroupFlowId}}/connections
+POST {{baseUrl}}/process-groups/{{processGroupId}}/connections
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
@@ -167,12 +167,12 @@ Content-Type: application/json
     "name": "",
     "source": {
       "id": "{{sourceProcessor}}",
-      "groupId": "{{processGroupFlowId}}",
+      "groupId": "{{processGroupId}}",
       "type": "PROCESSOR"
     },
     "destination": {
       "id": "{{destinationProcessor}}",
-      "groupId": "{{processGroupFlowId}}",
+      "groupId": "{{processGroupId}}",
       "type": "PROCESSOR"
     },
     "selectedRelationships": [
@@ -227,6 +227,42 @@ Content-Type: application/json
    }
 }
 
+### Create RecordReader
+POST {{baseUrl}}/process-groups/{{processGroupId}}/controller-services
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+   "revision":{
+      "clientId":"{{clientId}}",
+      "version":0
+   },
+   "disconnectedNodeAcknowledged":false,
+   "component":{
+      "type":"org.influxdata.nifi.serialization.InfluxLineProtocolReader",
+      "bundle":{
+         "group":"org.influxdata.nifi",
+         "artifact":"nifi-influx-database-nar",
+         "version":"1.13.0"
+      },
+      "name":"InfluxLineProtocolReader"
+   }
+}
+
+### Start the RecordReader Controller Service
+PUT {{baseUrl}}/controller-services/{{influxRecordReader}}/run-status
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+   "revision":{
+      "clientId":"{{clientId}}",
+      "version":2
+   },
+   "disconnectedNodeAcknowledged":false,
+   "state":"ENABLED"
+}
+
 ### Update Influx Processor
 PUT {{baseUrl}}/processors/{{destinationProcessor}}
 Authorization: Bearer {{token}}
@@ -235,14 +271,14 @@ Content-Type: application/json
 {
    "revision":{
       "clientId":"{{clientId}}",
-      "version":4
+      "version":3
    },
    "component":{
       "id":"{{destinationProcessor}}",
       "config":{
          "properties":{
-           "influxdb-bucket": "nifi",
-           "influxdb-org": "org",
+           "influxdb-bucket": "{{influxBucket}}}",
+           "influxdb-org": "{{influxOrg}}",
            "record-reader": "{{influxRecordReader}}"
          }
       }
@@ -251,7 +287,7 @@ Content-Type: application/json
 
 ###
 # Start Entire Process Group Flow Running
-PUT {{baseUrl}}/remote-process-groups/process-group/{{processGroupFlowId}}/run-status
+PUT {{baseUrl}}/remote-process-groups/process-group/{{processGroupId}}/run-status
 Authorization: Bearer {{token}}
 Content-Type: application/json
 


### PR DESCRIPTION
Runs x2 mqtt-clients publishing events with LP messages to two separate brokers at topics `/1` and `/2` respectively. These clients will run, publish a message, stop, run, publish a message, etc

Runs x2 mosquitto brokers at ports 1883 and 1884

Changes `processGroupFlowId` to `processGroupId` so processors are created inside the right group. 

Adds requests to create and enable the record reader